### PR TITLE
feat: 오디오 처리에 min_silence_len 파라미터 추가

### DIFF
--- a/core.py
+++ b/core.py
@@ -61,6 +61,7 @@ def run_infer_script(
     pth_path: str,
     index_path: str,
     split_audio: bool,
+    min_silence_len: int,
     f0_autotune: bool,
     f0_autotune_strength: float,
     proposed_pitch: bool,
@@ -124,6 +125,7 @@ def run_infer_script(
         "pth_path": pth_path,
         "index_path": index_path,
         "split_audio": split_audio,
+        "min_silence_len": min_silence_len,
         "f0_autotune": f0_autotune,
         "f0_autotune_strength": f0_autotune_strength,
         "proposed_pitch": proposed_pitch,
@@ -195,6 +197,7 @@ def run_batch_infer_script(
     pth_path: str,
     index_path: str,
     split_audio: bool,
+    min_silence_len: int,
     f0_autotune: bool,
     f0_autotune_strength: float,
     proposed_pitch: bool,
@@ -258,6 +261,7 @@ def run_batch_infer_script(
         "pth_path": pth_path,
         "index_path": index_path,
         "split_audio": split_audio,
+        "min_silence_len": min_silence_len,
         "f0_autotune": f0_autotune,
         "f0_autotune_strength": f0_autotune_strength,
         "proposed_pitch": proposed_pitch,
@@ -332,6 +336,7 @@ def run_tts_script(
     pth_path: str,
     index_path: str,
     split_audio: bool,
+    min_silence_len: int,
     f0_autotune: bool,
     f0_autotune_strength: float,
     proposed_pitch: bool,
@@ -378,6 +383,7 @@ def run_tts_script(
         model_path=pth_path,
         index_path=index_path,
         split_audio=split_audio,
+        min_silence_len=min_silence_len,
         f0_autotune=f0_autotune,
         f0_autotune_strength=f0_autotune_strength,
         proposed_pitch=proposed_pitch,
@@ -709,6 +715,14 @@ def parse_arguments():
         choices=[True, False],
         help=split_audio_description,
         default=False,
+    )
+    min_silence_len_description = "Minimum silence duration in milliseconds for audio splitting. Higher values create fewer, larger chunks."
+    infer_parser.add_argument(
+        "--min_silence_len",
+        type=int,
+        help=min_silence_len_description,
+        choices=range(100, 10001, 100),
+        default=3000,
     )
     f0_autotune_description = "Apply a light autotune to the inferred audio. Particularly useful for singing voice conversions."
     infer_parser.add_argument(
@@ -1230,6 +1244,13 @@ def parse_arguments():
         default=False,
     )
     batch_infer_parser.add_argument(
+        "--min_silence_len",
+        type=int,
+        help=min_silence_len_description,
+        choices=range(100, 10001, 100),
+        default=3000,
+    )
+    batch_infer_parser.add_argument(
         "--f0_autotune",
         type=lambda x: bool(strtobool(x)),
         choices=[True, False],
@@ -1714,6 +1735,13 @@ def parse_arguments():
         default=False,
     )
     tts_parser.add_argument(
+        "--min_silence_len",
+        type=int,
+        help=min_silence_len_description,
+        choices=range(100, 10001, 100),
+        default=3000,
+    )
+    tts_parser.add_argument(
         "--f0_autotune",
         type=lambda x: bool(strtobool(x)),
         choices=[True, False],
@@ -2187,6 +2215,7 @@ def main():
                 pth_path=args.pth_path,
                 index_path=args.index_path,
                 split_audio=args.split_audio,
+                min_silence_len=args.min_silence_len,
                 f0_autotune=args.f0_autotune,
                 f0_autotune_strength=args.f0_autotune_strength,
                 proposed_pitch=args.proposed_pitch,
@@ -2249,6 +2278,7 @@ def main():
                 pth_path=args.pth_path,
                 index_path=args.index_path,
                 split_audio=args.split_audio,
+                min_silence_len=args.min_silence_len,
                 f0_autotune=args.f0_autotune,
                 f0_autotune_strength=args.f0_autotune_strength,
                 proposed_pitch=args.proposed_pitch,
@@ -2315,6 +2345,7 @@ def main():
                 pth_path=args.pth_path,
                 index_path=args.index_path,
                 split_audio=args.split_audio,
+                min_silence_len=args.min_silence_len,
                 f0_autotune=args.f0_autotune,
                 f0_autotune_strength=args.f0_autotune_strength,
                 proposed_pitch=args.proposed_pitch,

--- a/rvc/infer/infer.py
+++ b/rvc/infer/infer.py
@@ -203,6 +203,7 @@ class VoiceConverter:
         protect: float = 0.5,
         hop_length: int = 128,
         split_audio: bool = False,
+        min_silence_len: int = 3000,
         f0_autotune: bool = False,
         f0_autotune_strength: float = 1,
         embedder_model: str = "contentvec",
@@ -280,7 +281,9 @@ class VoiceConverter:
                 self.tgt_sr = resample_sr
 
             if split_audio:
-                chunks, intervals = process_audio(audio, 16000)
+                chunks, intervals = process_audio(
+                    audio, 16000, silence_thresh=-60, min_silence_len=min_silence_len
+                )
                 print(f"Audio split into {len(chunks)} chunks for processing.")
             else:
                 chunks = []

--- a/rvc/lib/tools/split_audio.py
+++ b/rvc/lib/tools/split_audio.py
@@ -2,7 +2,7 @@ import numpy as np
 import librosa
 
 
-def process_audio(audio, sr=16000, silence_thresh=-60, min_silence_len=250):
+def process_audio(audio, sr=16000, silence_thresh=-60, min_silence_len=3000):
     """
     Splits an audio signal into segments using a fixed frame size and hop size.
 

--- a/tabs/inference/inference.py
+++ b/tabs/inference/inference.py
@@ -615,6 +615,18 @@ def inference_tab():
                     value=False,
                     interactive=True,
                 )
+                min_silence_len = gr.Slider(
+                    minimum=100,
+                    maximum=10000,
+                    step=100,
+                    label=i18n("Minimum Silence Length (ms)"),
+                    info=i18n(
+                        "Minimum silence duration in milliseconds for audio splitting. Higher values create fewer, larger chunks."
+                    ),
+                    visible=False,
+                    value=3000,
+                    interactive=True,
+                )
                 autotune = gr.Checkbox(
                     label=i18n("Autotune"),
                     info=i18n(
@@ -1308,6 +1320,18 @@ def inference_tab():
                     value=False,
                     interactive=True,
                 )
+                min_silence_len_batch = gr.Slider(
+                    minimum=100,
+                    maximum=10000,
+                    step=100,
+                    label=i18n("Minimum Silence Length (ms)"),
+                    info=i18n(
+                        "Minimum silence duration in milliseconds for audio splitting. Higher values create fewer, larger chunks."
+                    ),
+                    visible=False,
+                    value=3000,
+                    interactive=True,
+                )
                 autotune_batch = gr.Checkbox(
                     label=i18n("Autotune"),
                     info=i18n(
@@ -1886,6 +1910,9 @@ def inference_tab():
     def toggle_visible(checkbox):
         return {"visible": checkbox, "__type__": "update"}
 
+    def toggle_split_audio_visible(split_audio):
+        return {"visible": split_audio, "__type__": "update"}
+
     def toggle_visible_embedder_custom(embedder_model):
         if embedder_model == "custom":
             return {"visible": True, "__type__": "update"}
@@ -1945,6 +1972,16 @@ def inference_tab():
     def delay_visible(checkbox):
         return update_visibility(checkbox, 3)
 
+    split_audio.change(
+        fn=toggle_split_audio_visible,
+        inputs=[split_audio],
+        outputs=[min_silence_len],
+    )
+    split_audio_batch.change(
+        fn=toggle_split_audio_visible,
+        inputs=[split_audio_batch],
+        outputs=[min_silence_len_batch],
+    )
     autotune.change(
         fn=toggle_visible,
         inputs=[autotune],
@@ -2264,6 +2301,7 @@ def inference_tab():
             model_file,
             index_file,
             split_audio,
+            min_silence_len,
             autotune,
             autotune_strength,
             proposed_pitch,
@@ -2330,6 +2368,7 @@ def inference_tab():
             model_file,
             index_file,
             split_audio_batch,
+            min_silence_len_batch,
             autotune_batch,
             autotune_strength_batch,
             proposed_pitch_batch,


### PR DESCRIPTION
- 여러 스크립트에서 오디오 분할 시 최소 무음 길이를 제어할 수 있도록 새로운 파라미터 min_silence_len 을 도입
- 이 새로운 파라미터를 반영하기 위해 함수 시그니처와 인자 파싱을 업데이트
- 추론(inference) 탭에서 min_silence_len 을 설정할 수 있도록 사용자 인터페이스를 개선
- 개선된 청크 처리 동작을 위해 오디오 처리 로직에 해당 파라미터를 적용
<img width="1398" height="835" alt="스크린샷 2025-09-25 13-53-43" src="https://github.com/user-attachments/assets/e62ad3e6-4d83-4700-9510-110a3cb46a53" />

