### PR TITLE
Release 태그별 Applio 인스턴스를 탭에서 기동·임베드 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
-# VCS
-.git
+# VCS — .git은 Release Viewer 탭이 git worktree를 사용하므로 이미지에 포함한다
 .gitmodules
 .gitignore
 .github

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ venv
 
 # Below is AnAI Custom
 .idea/**/*
+
+.release_worktrees/

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     libportaudio2 \
     libatomic1 \
+    build-essential \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tk \
     tini \
     git \
+    libportaudio2 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tini \
     git \
     libportaudio2 \
+    libatomic1 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ffmpeg \
     tk \
     tini \
+    git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app /app
@@ -40,7 +41,7 @@ COPY --from=builder /app/.venv /app/.venv
 # 소스는 컨텍스트에서 복사: 자주 바뀌지만 작게 만들 수 있음
 COPY . /app
 
-EXPOSE 6969
+EXPOSE 6969 7001 7002 7003 7004 7005 7006 7007 7008 7009 7010
 VOLUME ["/app/logs/"]
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/app.py
+++ b/app.py
@@ -63,6 +63,12 @@ from tabs.voice_blender.voice_blender import voice_blender_tab
 from tabs.plugins.plugins import plugins_tab
 from tabs.settings.settings import settings_tab
 from tabs.preprocess.preprocessing import preprocessing_tab
+from tabs.release_viewer.release_viewer import release_viewer_tab
+from tabs.release_viewer.process_manager import stop_all as release_viewer_stop_all
+
+import atexit
+
+atexit.register(release_viewer_stop_all)
 
 # Run prerequisites
 from core import run_prerequisites_script
@@ -126,6 +132,9 @@ with gr.Blocks(
 
     with gr.Tab(i18n("Preprocessing")):
         preprocessing_tab()
+
+    with gr.Tab(i18n("Release Viewer")):
+        release_viewer_tab()
 
     gr.Markdown(
         """

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,3 +2,4 @@ services:
   applio:
     environment:
       - RUN_ENV=production
+      - RELEASE_VIEWER_BASE_URL=${RELEASE_VIEWER_BASE_URL:-http://applio.an-ai.ooo}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,4 +2,5 @@ services:
   applio:
     environment:
       - RUN_ENV=production
-      - RELEASE_VIEWER_BASE_URL=${RELEASE_VIEWER_BASE_URL:-http://applio.an-ai.ooo}
+      - RELEASE_VIEWER_BASE_URL=${RELEASE_VIEWER_BASE_URL:-https://applio.an-ai.ooo}
+      - RELEASE_VIEWER_URL_MODE=path

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       dockerfile: Dockerfile
     ports:
       - "6969:6969"
+      - "7001-7010:7001-7010"
     container_name: anai-applio
     restart: always
     environment:
@@ -14,6 +15,11 @@ services:
       - RABBIT_URL=amqp://anai:ydVyM3KDkJ@rabbitmq:5672/
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
       - JOB_INDEX_REDIS_URL=redis://redis:6379/2
+      - RELEASE_VIEWER_BASE_URL=${RELEASE_VIEWER_BASE_URL:-http://localhost}
+      - RELEASE_VIEWER_SHARED_LOGS=/app/logs
+      - RELEASE_VIEWER_SHARED_MODELS=/app/rvc/models
+      - RELEASE_VIEWER_SHARED_DATASETS=/app/assets/datasets
+      - RELEASE_VIEWER_SHARED_AUDIOS=/app/assets/audios
     volumes:
       - "${HOME}/.aws:/root/.aws:ro"
       - type: volume
@@ -28,6 +34,9 @@ services:
       - type: volume
         source: nfs_applio_audios
         target: /app/assets/audios
+      - type: volume
+        source: applio_release_worktrees
+        target: /app/.release_worktrees
     shm_size: "48gb"
     depends_on:
       - rabbitmq
@@ -68,6 +77,7 @@ services:
 volumes:
   rabbitmq_data:
   redis_data:
+  applio_release_worktrees:
 
   nfs_applio_logs:
     driver: local

--- a/tabs/release_viewer/config.py
+++ b/tabs/release_viewer/config.py
@@ -13,6 +13,8 @@ PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WORKTREE_DIR = PROJECT_ROOT / ".release_worktrees"
 
 BASE_URL = os.getenv("RELEASE_VIEWER_BASE_URL", "http://localhost").rstrip("/")
+URL_MODE = os.getenv("RELEASE_VIEWER_URL_MODE", "port").lower()
+URL_PATH_PREFIX = os.getenv("RELEASE_VIEWER_URL_PATH_PREFIX", "/release").rstrip("/")
 _parsed = urlparse(BASE_URL)
 IFRAME_SCHEME = _parsed.scheme or "http"
 IFRAME_HOST = _parsed.hostname or "localhost"
@@ -41,5 +43,14 @@ def find_release(tag: str) -> dict | None:
     return None
 
 
+def gradio_root_path(release: dict) -> str | None:
+    """URL 모드가 path인 경우 자식 Applio가 사용해야 하는 GRADIO_ROOT_PATH."""
+    if URL_MODE != "path":
+        return None
+    return f"{URL_PATH_PREFIX}/{release['tag']}"
+
+
 def resolve_url(release: dict) -> str:
+    if URL_MODE == "path":
+        return f"{BASE_URL}{URL_PATH_PREFIX}/{release['tag']}/"
     return f"{BASE_URL}:{release['port']}/"

--- a/tabs/release_viewer/config.py
+++ b/tabs/release_viewer/config.py
@@ -1,15 +1,23 @@
 """Release Viewer 탭 설정.
 
 각 release 태그에 대해 git worktree로 체크아웃하고 고정 포트로
-태그 버전 Applio를 기동한다. iframe은 해당 localhost 포트를 가리킨다.
+태그 버전 Applio를 기동한다. iframe은 RELEASE_VIEWER_BASE_URL 환경변수의
+호스트(기본값 http://localhost)에 태그별 포트를 붙여 렌더한다.
 """
 
+import os
 from pathlib import Path
+from urllib.parse import urlparse
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 WORKTREE_DIR = PROJECT_ROOT / ".release_worktrees"
 
-IFRAME_HOST = "localhost"
+BASE_URL = os.getenv("RELEASE_VIEWER_BASE_URL", "http://localhost").rstrip("/")
+_parsed = urlparse(BASE_URL)
+IFRAME_SCHEME = _parsed.scheme or "http"
+IFRAME_HOST = _parsed.hostname or "localhost"
+ALLOWED_HOSTS: set[str] = {IFRAME_HOST, "localhost", "127.0.0.1"}
+
 READY_TIMEOUT_SEC = 300
 
 RELEASES: list[dict] = [
@@ -34,4 +42,4 @@ def find_release(tag: str) -> dict | None:
 
 
 def resolve_url(release: dict) -> str:
-    return f"http://{IFRAME_HOST}:{release['port']}/"
+    return f"{BASE_URL}:{release['port']}/"

--- a/tabs/release_viewer/config.py
+++ b/tabs/release_viewer/config.py
@@ -1,0 +1,37 @@
+"""Release Viewer 탭 설정.
+
+각 release 태그에 대해 git worktree로 체크아웃하고 고정 포트로
+태그 버전 Applio를 기동한다. iframe은 해당 localhost 포트를 가리킨다.
+"""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WORKTREE_DIR = PROJECT_ROOT / ".release_worktrees"
+
+IFRAME_HOST = "localhost"
+READY_TIMEOUT_SEC = 300
+
+RELEASES: list[dict] = [
+    {"tag": "3.6.2", "label": "3.6.2", "port": 7001},
+    {"tag": "3.6.1", "label": "3.6.1", "port": 7002},
+    {"tag": "3.6.0", "label": "3.6.0", "port": 7003},
+    {"tag": "3.5.1", "label": "3.5.1", "port": 7004},
+    {"tag": "3.5.0", "label": "3.5.0", "port": 7005},
+    {"tag": "3.4.0", "label": "3.4.0", "port": 7006},
+    {"tag": "3.3.1", "label": "3.3.1", "port": 7007},
+    {"tag": "3.3.0", "label": "3.3.0", "port": 7008},
+    {"tag": "3.2.9", "label": "3.2.9", "port": 7009},
+    {"tag": "3.2.8", "label": "3.2.8", "port": 7010},
+]
+
+
+def find_release(tag: str) -> dict | None:
+    for release in RELEASES:
+        if release["tag"] == tag or release["label"] == tag:
+            return release
+    return None
+
+
+def resolve_url(release: dict) -> str:
+    return f"http://{IFRAME_HOST}:{release['port']}/"

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -1,12 +1,14 @@
 """Release 태그별 git worktree / uv venv / Applio subprocess 수명주기 관리."""
 
 import os
+import re
 import socket
 import subprocess
 import threading
 import time
 import urllib.error
 import urllib.request
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -15,6 +17,19 @@ from tabs.release_viewer.config import (
     READY_TIMEOUT_SEC,
     WORKTREE_DIR,
 )
+
+LOG_DIR = WORKTREE_DIR / "_logs"
+
+
+def _shared_links() -> list[tuple[str, str]]:
+    """(worktree 내부 상대경로, 부모 절대경로) 쌍 목록."""
+    mapping = [
+        ("logs", os.getenv("RELEASE_VIEWER_SHARED_LOGS", "")),
+        ("rvc/models", os.getenv("RELEASE_VIEWER_SHARED_MODELS", "")),
+        ("assets/datasets", os.getenv("RELEASE_VIEWER_SHARED_DATASETS", "")),
+        ("assets/audios", os.getenv("RELEASE_VIEWER_SHARED_AUDIOS", "")),
+    ]
+    return [(sub, target) for sub, target in mapping if target]
 
 Status = Literal["stopped", "starting", "running", "error"]
 
@@ -53,20 +68,136 @@ def ensure_worktree(tag: str) -> Path:
     verify_git_repo()
     WORKTREE_DIR.mkdir(parents=True, exist_ok=True)
     worktree_path = WORKTREE_DIR / tag
-    if worktree_path.exists() and (worktree_path / ".git").exists():
-        return worktree_path
-    _run(
-        ["git", "worktree", "add", str(worktree_path), tag],
-        cwd=PROJECT_ROOT,
-        timeout=120,
-    )
+    if not (worktree_path.exists() and (worktree_path / ".git").exists()):
+        _run(
+            ["git", "worktree", "add", str(worktree_path), tag],
+            cwd=PROJECT_ROOT,
+            timeout=120,
+        )
+    setup_shared_links(worktree_path)
     return worktree_path
 
 
+def setup_shared_links(worktree: Path) -> None:
+    """worktree 내부 경로를 부모의 공유 데이터 경로로 심볼릭 링크한다.
+
+    - 대상이 없는(env 미설정) 항목은 스킵 → 로컬 개발 호환
+    - 이미 올바른 symlink면 스킵
+    - 실존 디렉토리/파일이 있으면 `.bak_<timestamp>`로 이름 변경 후 교체
+    """
+    for sub_path, target in _shared_links():
+        link = worktree / sub_path
+        target_path = Path(target)
+        if not target_path.exists():
+            continue
+        if link.is_symlink():
+            try:
+                if link.resolve() == target_path.resolve():
+                    continue
+            except OSError:
+                pass
+            link.unlink()
+        elif link.exists():
+            timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+            backup = link.with_name(f"{link.name}.bak_{timestamp}")
+            link.rename(backup)
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(target_path, target_is_directory=True)
+
+
+def _venv_python(worktree: Path) -> Path:
+    return worktree / ".venv" / "bin" / "python"
+
+
+def _parse_install_script(worktree: Path) -> tuple[str, list[str]]:
+    """run-install.sh에서 Python 버전과 pip 플래그를 파싱한다.
+
+    기본값: Python 3.12, 추가 플래그 없음.
+    """
+    script = worktree / "run-install.sh"
+    python_version = "3.12"
+    extra_args: list[str] = []
+    if not script.exists():
+        return python_version, extra_args
+    try:
+        content = script.read_text(errors="replace")
+    except OSError:
+        return python_version, extra_args
+    m = re.search(r"uv\s+venv[^\n]*--python\s+(\d+\.\d+)", content)
+    if m:
+        python_version = m.group(1)
+    m = re.search(r"--extra-index-url\s+(\S+)", content)
+    if m:
+        extra_args += ["--extra-index-url", m.group(1)]
+    m = re.search(r"--index-strategy\s+(\S+)", content)
+    if m:
+        extra_args += ["--index-strategy", m.group(1)]
+    return python_version, extra_args
+
+
 def ensure_venv(worktree: Path) -> None:
-    if (worktree / ".venv").exists():
+    if _venv_python(worktree).exists():
         return
-    _run(["uv", "sync"], cwd=worktree, timeout=3600)
+    has_uv_lock = (worktree / "uv.lock").exists()
+    has_pyproject = (worktree / "pyproject.toml").exists()
+    has_requirements = (worktree / "requirements.txt").exists()
+
+    if has_uv_lock and has_pyproject:
+        _run(["uv", "sync"], cwd=worktree, timeout=3600)
+        return
+
+    python_version, extra_pip_args = _parse_install_script(worktree)
+    _run(
+        ["uv", "venv", ".venv", "--python", python_version],
+        cwd=worktree,
+        timeout=600,
+    )
+    _run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(_venv_python(worktree)),
+            "setuptools<81",
+            "wheel",
+        ],
+        cwd=worktree,
+        timeout=300,
+    )
+    if has_requirements:
+        _run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(_venv_python(worktree)),
+                "-r",
+                "requirements.txt",
+                *extra_pip_args,
+            ],
+            cwd=worktree,
+            timeout=3600,
+        )
+    elif has_pyproject:
+        _run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(_venv_python(worktree)),
+                "-e",
+                ".",
+            ],
+            cwd=worktree,
+            timeout=3600,
+        )
+    else:
+        raise ReleaseError(
+            f"의존성 정의 파일을 찾을 수 없습니다 (uv.lock / pyproject.toml / requirements.txt): {worktree}"
+        )
 
 
 def _is_port_in_use(port: int) -> bool:
@@ -99,34 +230,68 @@ def start_process(release: dict) -> subprocess.Popen:
             raise ReleaseError(
                 f"worktree가 준비되지 않았습니다: {worktree}"
             )
+        python_bin = _venv_python(worktree)
+        if not python_bin.exists():
+            raise ReleaseError(
+                f"venv의 python을 찾을 수 없습니다: {python_bin}"
+            )
         env = os.environ.copy()
+        env.pop("GRADIO_ROOT_PATH", None)
+        env.pop("VIRTUAL_ENV", None)
+        env.pop("PYTHONPATH", None)
+        env["PATH"] = f"{worktree / '.venv' / 'bin'}:{env.get('PATH', '')}"
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        log_path = LOG_DIR / f"{tag}.log"
+        log_file = open(log_path, "ab", buffering=0)
         popen = subprocess.Popen(
-            ["uv", "run", "python", "app.py", "--port", str(port)],
+            [str(python_bin), "app.py", "--port", str(port)],
             cwd=str(worktree),
             env=env,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
             start_new_session=False,
         )
         _processes[tag] = popen
         return popen
 
 
-def wait_until_ready(port: int, timeout: int = READY_TIMEOUT_SEC) -> bool:
+def read_log_tail(tag: str, lines: int = 30) -> str:
+    log_path = LOG_DIR / f"{tag}.log"
+    if not log_path.exists():
+        return "(로그 파일이 없습니다)"
+    try:
+        content = log_path.read_text(errors="replace").splitlines()
+    except OSError as exc:
+        return f"(로그 읽기 실패: {exc})"
+    return "\n".join(content[-lines:]) or "(로그가 비어 있습니다)"
+
+
+def wait_until_ready(
+    tag: str,
+    port: int,
+    timeout: int = READY_TIMEOUT_SEC,
+) -> tuple[bool, str]:
+    """포트가 준비되면 (True, ""), 실패하면 (False, 사유)를 반환."""
     url = f"http://127.0.0.1:{port}/"
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
+        popen = _processes.get(tag)
+        if popen is None:
+            return False, "프로세스가 등록되어 있지 않습니다"
+        rc = popen.poll()
+        if rc is not None:
+            return False, f"자식 프로세스가 종료되었습니다 (exit={rc})"
         try:
             with urllib.request.urlopen(url, timeout=2) as resp:
                 if resp.status < 500:
-                    return True
+                    return True, ""
         except urllib.error.HTTPError as exc:
             if exc.code < 500:
-                return True
+                return True, ""
         except (urllib.error.URLError, ConnectionError, OSError):
             pass
         time.sleep(1.0)
-    return False
+    return False, f"타임아웃 ({timeout}초)"
 
 
 def stop_process(tag: str) -> bool:

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -1,0 +1,163 @@
+"""Release 태그별 git worktree / uv venv / Applio subprocess 수명주기 관리."""
+
+import os
+import socket
+import subprocess
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Literal
+
+from tabs.release_viewer.config import (
+    PROJECT_ROOT,
+    READY_TIMEOUT_SEC,
+    WORKTREE_DIR,
+)
+
+Status = Literal["stopped", "starting", "running", "error"]
+
+_processes: dict[str, subprocess.Popen] = {}
+_lock = threading.Lock()
+
+
+class ReleaseError(RuntimeError):
+    """Release Viewer 관련 복구 가능한 에러."""
+
+
+def _run(cmd: list[str], cwd: Path | None = None, timeout: int | None = None) -> str:
+    try:
+        result = subprocess.run(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ReleaseError(f"명령 시간 초과: {' '.join(cmd)}") from exc
+    except FileNotFoundError as exc:
+        raise ReleaseError(f"명령을 찾을 수 없음: {cmd[0]}") from exc
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "").strip().splitlines()[-20:]
+        raise ReleaseError("\n".join(tail) or f"명령 실패: {' '.join(cmd)}")
+    return result.stdout
+
+
+def verify_git_repo() -> None:
+    _run(["git", "rev-parse", "--git-dir"], cwd=PROJECT_ROOT)
+
+
+def ensure_worktree(tag: str) -> Path:
+    verify_git_repo()
+    WORKTREE_DIR.mkdir(parents=True, exist_ok=True)
+    worktree_path = WORKTREE_DIR / tag
+    if worktree_path.exists() and (worktree_path / ".git").exists():
+        return worktree_path
+    _run(
+        ["git", "worktree", "add", str(worktree_path), tag],
+        cwd=PROJECT_ROOT,
+        timeout=120,
+    )
+    return worktree_path
+
+
+def ensure_venv(worktree: Path) -> None:
+    if (worktree / ".venv").exists():
+        return
+    _run(["uv", "sync"], cwd=worktree, timeout=3600)
+
+
+def _is_port_in_use(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.5)
+        try:
+            sock.connect(("127.0.0.1", port))
+            return True
+        except (ConnectionRefusedError, OSError):
+            return False
+
+
+def _popen_alive(popen: subprocess.Popen | None) -> bool:
+    return popen is not None and popen.poll() is None
+
+
+def start_process(release: dict) -> subprocess.Popen:
+    tag = release["tag"]
+    port = release["port"]
+    with _lock:
+        existing = _processes.get(tag)
+        if _popen_alive(existing):
+            return existing
+        if _is_port_in_use(port):
+            raise ReleaseError(
+                f"포트 {port}가 이미 사용 중입니다. (태그 {tag})"
+            )
+        worktree = WORKTREE_DIR / tag
+        if not worktree.exists():
+            raise ReleaseError(
+                f"worktree가 준비되지 않았습니다: {worktree}"
+            )
+        env = os.environ.copy()
+        popen = subprocess.Popen(
+            ["uv", "run", "python", "app.py", "--port", str(port)],
+            cwd=str(worktree),
+            env=env,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=False,
+        )
+        _processes[tag] = popen
+        return popen
+
+
+def wait_until_ready(port: int, timeout: int = READY_TIMEOUT_SEC) -> bool:
+    url = f"http://127.0.0.1:{port}/"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as resp:
+                if resp.status < 500:
+                    return True
+        except urllib.error.HTTPError as exc:
+            if exc.code < 500:
+                return True
+        except (urllib.error.URLError, ConnectionError, OSError):
+            pass
+        time.sleep(1.0)
+    return False
+
+
+def stop_process(tag: str) -> bool:
+    with _lock:
+        popen = _processes.pop(tag, None)
+        if not _popen_alive(popen):
+            return False
+        popen.terminate()
+        try:
+            popen.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            popen.kill()
+            popen.wait(timeout=5)
+        return True
+
+
+def stop_all() -> None:
+    with _lock:
+        tags = list(_processes.keys())
+    for tag in tags:
+        try:
+            stop_process(tag)
+        except Exception:
+            pass
+
+
+def get_status(tag: str, port: int) -> Status:
+    with _lock:
+        popen = _processes.get(tag)
+    if not _popen_alive(popen):
+        return "stopped"
+    if _is_port_in_use(port):
+        return "running"
+    return "starting"

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -5,6 +5,7 @@ import re
 import shutil
 import socket
 import subprocess
+import sys
 import threading
 import time
 import urllib.error
@@ -268,6 +269,34 @@ def _popen_alive(popen: subprocess.Popen | None) -> bool:
     return popen is not None and popen.poll() is None
 
 
+def _tee_output(tag: str, popen: subprocess.Popen, log_file) -> None:
+    """자식 stdout을 파일(원문)과 부모 stdout(프리픽스)에 동시에 기록."""
+    prefix = f"[release-viewer:{tag}] "
+    try:
+        assert popen.stdout is not None
+        for raw in iter(popen.stdout.readline, b""):
+            try:
+                log_file.write(raw)
+            except OSError:
+                pass
+            try:
+                line = raw.decode("utf-8", errors="replace").rstrip("\n")
+                sys.stdout.write(prefix + line + "\n")
+                sys.stdout.flush()
+            except Exception:
+                pass
+    finally:
+        try:
+            log_file.close()
+        except OSError:
+            pass
+        try:
+            if popen.stdout is not None:
+                popen.stdout.close()
+        except OSError:
+            pass
+
+
 def start_process(release: dict) -> subprocess.Popen:
     tag = release["tag"]
     port = release["port"]
@@ -311,10 +340,18 @@ def start_process(release: dict) -> subprocess.Popen:
             ],
             cwd=str(worktree),
             env=env,
-            stdout=log_file,
+            stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
+            bufsize=0,
             start_new_session=False,
         )
+        tee_thread = threading.Thread(
+            target=_tee_output,
+            args=(tag, popen, log_file),
+            name=f"release-viewer-tee-{tag}",
+            daemon=True,
+        )
+        tee_thread.start()
         _processes[tag] = popen
         return popen
 

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -188,7 +188,7 @@ def ensure_venv(worktree: Path) -> None:
             "install",
             "--python",
             str(_venv_python(worktree)),
-            "setuptools<81",
+            "setuptools<77",
             "wheel",
         ],
         cwd=worktree,

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+import shutil
 import socket
 import subprocess
 import threading
@@ -135,6 +136,10 @@ def _venv_python(worktree: Path) -> Path:
     return worktree / ".venv" / "bin" / "python"
 
 
+def _venv_ready_marker(worktree: Path) -> Path:
+    return worktree / ".venv" / ".release_viewer_ready"
+
+
 def _parse_install_script(worktree: Path) -> tuple[str, list[str]]:
     """run-install.sh에서 Python 버전과 pip 플래그를 파싱한다.
 
@@ -162,14 +167,19 @@ def _parse_install_script(worktree: Path) -> tuple[str, list[str]]:
 
 
 def ensure_venv(worktree: Path) -> None:
-    if _venv_python(worktree).exists():
+    marker = _venv_ready_marker(worktree)
+    if marker.exists():
         return
+    venv_dir = worktree / ".venv"
+    if venv_dir.exists():
+        shutil.rmtree(venv_dir)
     has_uv_lock = (worktree / "uv.lock").exists()
     has_pyproject = (worktree / "pyproject.toml").exists()
     has_requirements = (worktree / "requirements.txt").exists()
 
     if has_uv_lock and has_pyproject:
         _run(["uv", "sync"], cwd=worktree, timeout=3600)
+        marker.touch()
         return
 
     python_version, extra_pip_args = _parse_install_script(worktree)
@@ -227,6 +237,7 @@ def ensure_venv(worktree: Path) -> None:
         raise ReleaseError(
             f"의존성 정의 파일을 찾을 수 없습니다 (uv.lock / pyproject.toml / requirements.txt): {worktree}"
         )
+    marker.touch()
 
 
 def _is_port_in_use(port: int) -> bool:

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -276,7 +276,14 @@ def start_process(release: dict) -> subprocess.Popen:
         log_path = LOG_DIR / f"{tag}.log"
         log_file = open(log_path, "ab", buffering=0)
         popen = subprocess.Popen(
-            [str(python_bin), "app.py", "--port", str(port)],
+            [
+                str(python_bin),
+                "app.py",
+                "--port",
+                str(port),
+                "--server-name",
+                "0.0.0.0",
+            ],
             cwd=str(worktree),
             env=env,
             stdout=log_file,

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -144,6 +144,10 @@ def _parse_install_script(worktree: Path) -> tuple[str, list[str]]:
     """run-install.sh에서 Python 버전과 pip 플래그를 파싱한다.
 
     기본값: Python 3.12, 추가 플래그 없음.
+    Python 버전 우선순위:
+      1. `uv venv ... --python X.Y`
+      2. `find_python` 스타일: `for py in python3.X python3 python`
+      3. `python@X.Y` (homebrew 스타일)
     """
     script = worktree / "run-install.sh"
     python_version = "3.12"
@@ -154,9 +158,19 @@ def _parse_install_script(worktree: Path) -> tuple[str, list[str]]:
         content = script.read_text(errors="replace")
     except OSError:
         return python_version, extra_args
+
     m = re.search(r"uv\s+venv[^\n]*--python\s+(\d+\.\d+)", content)
     if m:
         python_version = m.group(1)
+    else:
+        m = re.search(r"for\s+py\s+in\s+python(\d+\.\d+)", content)
+        if m:
+            python_version = m.group(1)
+        else:
+            m = re.search(r"python@(\d+\.\d+)", content)
+            if m:
+                python_version = m.group(1)
+
     m = re.search(r"--extra-index-url\s+(\S+)", content)
     if m:
         extra_args += ["--extra-index-url", m.group(1)]

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -326,6 +326,20 @@ def start_process(release: dict) -> subprocess.Popen:
         root_path = gradio_root_path(release)
         if root_path:
             env["GRADIO_ROOT_PATH"] = root_path
+        allowed_paths: list[str] = []
+        for raw in (env.get("GRADIO_ALLOWED_PATHS", "") or "").split(","):
+            item = raw.strip()
+            if item and item not in allowed_paths:
+                allowed_paths.append(item)
+        for _, target in _shared_links():
+            try:
+                resolved = str(Path(target).resolve())
+            except OSError:
+                continue
+            if resolved not in allowed_paths and Path(resolved).exists():
+                allowed_paths.append(resolved)
+        if allowed_paths:
+            env["GRADIO_ALLOWED_PATHS"] = ",".join(allowed_paths)
         LOG_DIR.mkdir(parents=True, exist_ok=True)
         log_path = LOG_DIR / f"{tag}.log"
         log_file = open(log_path, "ab", buffering=0)

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -16,6 +16,7 @@ from tabs.release_viewer.config import (
     PROJECT_ROOT,
     READY_TIMEOUT_SEC,
     WORKTREE_DIR,
+    gradio_root_path,
 )
 
 LOG_DIR = WORKTREE_DIR / "_logs"
@@ -268,6 +269,9 @@ def start_process(release: dict) -> subprocess.Popen:
         env.pop("VIRTUAL_ENV", None)
         env.pop("PYTHONPATH", None)
         env["PATH"] = f"{worktree / '.venv' / 'bin'}:{env.get('PATH', '')}"
+        root_path = gradio_root_path(release)
+        if root_path:
+            env["GRADIO_ROOT_PATH"] = root_path
         LOG_DIR.mkdir(parents=True, exist_ok=True)
         log_path = LOG_DIR / f"{tag}.log"
         log_file = open(log_path, "ab", buffering=0)

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -64,11 +64,30 @@ def verify_git_repo() -> None:
     _run(["git", "rev-parse", "--git-dir"], cwd=PROJECT_ROOT)
 
 
+def _tag_exists_locally(tag: str) -> bool:
+    result = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", f"refs/tags/{tag}"],
+        cwd=str(PROJECT_ROOT),
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+def fetch_tag(tag: str) -> None:
+    _run(
+        ["git", "fetch", "origin", "--no-tags", f"refs/tags/{tag}:refs/tags/{tag}"],
+        cwd=PROJECT_ROOT,
+        timeout=600,
+    )
+
+
 def ensure_worktree(tag: str) -> Path:
     verify_git_repo()
     WORKTREE_DIR.mkdir(parents=True, exist_ok=True)
     worktree_path = WORKTREE_DIR / tag
     if not (worktree_path.exists() and (worktree_path / ".git").exists()):
+        if not _tag_exists_locally(tag):
+            fetch_tag(tag)
         _run(
             ["git", "worktree", "add", str(worktree_path), tag],
             cwd=PROJECT_ROOT,

--- a/tabs/release_viewer/process_manager.py
+++ b/tabs/release_viewer/process_manager.py
@@ -41,7 +41,12 @@ class ReleaseError(RuntimeError):
     """Release Viewer 관련 복구 가능한 에러."""
 
 
-def _run(cmd: list[str], cwd: Path | None = None, timeout: int | None = None) -> str:
+def _run(
+    cmd: list[str],
+    cwd: Path | None = None,
+    timeout: int | None = None,
+    env: dict[str, str] | None = None,
+) -> str:
     try:
         result = subprocess.run(
             cmd,
@@ -49,6 +54,7 @@ def _run(cmd: list[str], cwd: Path | None = None, timeout: int | None = None) ->
             capture_output=True,
             text=True,
             timeout=timeout,
+            env=env,
         )
     except subprocess.TimeoutExpired as exc:
         raise ReleaseError(f"명령 시간 초과: {' '.join(cmd)}") from exc
@@ -166,10 +172,13 @@ def ensure_venv(worktree: Path) -> None:
         return
 
     python_version, extra_pip_args = _parse_install_script(worktree)
+    uv_env = os.environ.copy()
+    uv_env["UV_PYTHON_DOWNLOADS"] = "automatic"
     _run(
         ["uv", "venv", ".venv", "--python", python_version],
         cwd=worktree,
         timeout=600,
+        env=uv_env,
     )
     _run(
         [

--- a/tabs/release_viewer/release_viewer.py
+++ b/tabs/release_viewer/release_viewer.py
@@ -1,3 +1,4 @@
+import sys
 from urllib.parse import urlparse
 
 import gradio as gr
@@ -30,6 +31,10 @@ EMPTY_IFRAME = (
 )
 
 
+def _log(msg: str) -> None:
+    print(f"[release-viewer] {msg}", file=sys.stdout, flush=True)
+
+
 def _iframe_html(url: str) -> str:
     parsed = urlparse(url)
     if parsed.scheme not in ("http", "https") or parsed.hostname not in ALLOWED_HOSTS:
@@ -47,29 +52,37 @@ def _iframe_html(url: str) -> str:
 def _start_flow(label: str):
     release = find_release(label)
     if release is None:
+        _log(f"start: 알 수 없는 태그 label={label!r}")
         yield "알 수 없는 태그입니다.", EMPTY_IFRAME
         return
     tag = release["tag"]
     port = release["port"]
+    _log(f"start 요청: tag={tag} port={port}")
 
     status = get_status(tag, port)
     if status == "running":
+        _log(f"이미 실행 중: tag={tag} port={port}")
         yield f"이미 실행 중입니다 (포트 {port})", _iframe_html(resolve_url(release))
         return
 
     try:
+        _log(f"worktree 준비 중: tag={tag}")
         yield f"worktree 준비 중... ({tag})", EMPTY_IFRAME
         worktree = ensure_worktree(tag)
 
+        _log(f"의존성 설치 확인: tag={tag} worktree={worktree}")
         yield "의존성 설치 중... (최초 1회는 수 분 소요)", EMPTY_IFRAME
         ensure_venv(worktree)
 
+        _log(f"Applio 기동: tag={tag} port={port}")
         yield f"Applio 기동 중... (포트 {port})", EMPTY_IFRAME
         start_process(release)
 
+        _log(f"ready 대기: tag={tag} port={port}")
         yield "기동 완료 대기 중... (최대 300초)", EMPTY_IFRAME
         ready, reason = wait_until_ready(tag, port)
         if not ready:
+            _log(f"기동 실패: tag={tag} reason={reason}")
             tail = read_log_tail(tag, lines=30)
             yield (
                 f"기동 실패: {reason}\n\n```\n{tail}\n```",
@@ -77,21 +90,29 @@ def _start_flow(label: str):
             )
             return
 
+        _log(f"기동 성공: tag={tag} port={port}")
         yield f"실행 중 (포트 {port})", _iframe_html(resolve_url(release))
     except ReleaseError as exc:
+        _log(f"ReleaseError: tag={tag} {exc}")
         yield f"실패: {exc}", EMPTY_IFRAME
     except Exception as exc:  # noqa: BLE001
+        _log(f"예기치 못한 에러: tag={tag} {exc!r}")
         yield f"예기치 못한 에러: {exc}", EMPTY_IFRAME
 
 
 def _stop_flow(label: str):
     release = find_release(label)
     if release is None:
+        _log(f"stop: 알 수 없는 태그 label={label!r}")
         return "알 수 없는 태그입니다.", EMPTY_IFRAME
-    stopped = stop_process(release["tag"])
+    tag = release["tag"]
+    _log(f"stop 요청: tag={tag}")
+    stopped = stop_process(tag)
     if stopped:
-        return f"정지됨 ({release['tag']})", EMPTY_IFRAME
-    return f"실행 중인 프로세스가 없습니다 ({release['tag']})", EMPTY_IFRAME
+        _log(f"정지됨: tag={tag}")
+        return f"정지됨 ({tag})", EMPTY_IFRAME
+    _log(f"정지: 실행 중인 프로세스 없음 tag={tag}")
+    return f"실행 중인 프로세스가 없습니다 ({tag})", EMPTY_IFRAME
 
 
 def release_viewer_tab():

--- a/tabs/release_viewer/release_viewer.py
+++ b/tabs/release_viewer/release_viewer.py
@@ -47,51 +47,51 @@ def _iframe_html(url: str) -> str:
 def _start_flow(label: str):
     release = find_release(label)
     if release is None:
-        yield "❌ 알 수 없는 태그입니다.", EMPTY_IFRAME
+        yield "알 수 없는 태그입니다.", EMPTY_IFRAME
         return
     tag = release["tag"]
     port = release["port"]
 
     status = get_status(tag, port)
     if status == "running":
-        yield f"✅ 이미 실행 중입니다 (포트 {port})", _iframe_html(resolve_url(release))
+        yield f"이미 실행 중입니다 (포트 {port})", _iframe_html(resolve_url(release))
         return
 
     try:
-        yield f"⏳ worktree 준비 중… ({tag})", EMPTY_IFRAME
+        yield f"worktree 준비 중... ({tag})", EMPTY_IFRAME
         worktree = ensure_worktree(tag)
 
-        yield "🔄 의존성 설치 중… (uv sync, 최초 1회는 수 분 소요)", EMPTY_IFRAME
+        yield "의존성 설치 중... (최초 1회는 수 분 소요)", EMPTY_IFRAME
         ensure_venv(worktree)
 
-        yield f"🚀 Applio 기동 중… (포트 {port})", EMPTY_IFRAME
+        yield f"Applio 기동 중... (포트 {port})", EMPTY_IFRAME
         start_process(release)
 
-        yield "⌛ 기동 완료 대기 중… (최대 300초)", EMPTY_IFRAME
+        yield "기동 완료 대기 중... (최대 300초)", EMPTY_IFRAME
         ready, reason = wait_until_ready(tag, port)
         if not ready:
             tail = read_log_tail(tag, lines=30)
             yield (
-                f"❌ 기동 실패: {reason}\n\n```\n{tail}\n```",
+                f"기동 실패: {reason}\n\n```\n{tail}\n```",
                 EMPTY_IFRAME,
             )
             return
 
-        yield f"✅ 실행 중 (포트 {port})", _iframe_html(resolve_url(release))
+        yield f"실행 중 (포트 {port})", _iframe_html(resolve_url(release))
     except ReleaseError as exc:
-        yield f"❌ 실패: {exc}", EMPTY_IFRAME
+        yield f"실패: {exc}", EMPTY_IFRAME
     except Exception as exc:  # noqa: BLE001
-        yield f"❌ 예기치 못한 에러: {exc}", EMPTY_IFRAME
+        yield f"예기치 못한 에러: {exc}", EMPTY_IFRAME
 
 
 def _stop_flow(label: str):
     release = find_release(label)
     if release is None:
-        return "❌ 알 수 없는 태그입니다.", EMPTY_IFRAME
+        return "알 수 없는 태그입니다.", EMPTY_IFRAME
     stopped = stop_process(release["tag"])
     if stopped:
-        return f"🛑 정지됨 ({release['tag']})", EMPTY_IFRAME
-    return f"ℹ️ 실행 중인 프로세스가 없습니다 ({release['tag']})", EMPTY_IFRAME
+        return f"정지됨 ({release['tag']})", EMPTY_IFRAME
+    return f"실행 중인 프로세스가 없습니다 ({release['tag']})", EMPTY_IFRAME
 
 
 def release_viewer_tab():
@@ -112,8 +112,8 @@ def release_viewer_tab():
             interactive=True,
             scale=3,
         )
-        start_btn = gr.Button(i18n("▶ Start"), variant="primary", scale=1)
-        stop_btn = gr.Button(i18n("■ Stop"), variant="stop", scale=1)
+        start_btn = gr.Button(i18n("Start"), variant="primary", scale=1)
+        stop_btn = gr.Button(i18n("Stop"), variant="stop", scale=1)
 
     status_md = gr.Markdown(i18n("대기 중"))
     iframe_html = gr.HTML(value=EMPTY_IFRAME)

--- a/tabs/release_viewer/release_viewer.py
+++ b/tabs/release_viewer/release_viewer.py
@@ -1,0 +1,120 @@
+import gradio as gr
+
+from assets.i18n.i18n import I18nAuto
+from tabs.release_viewer.config import RELEASES, find_release, resolve_url
+from tabs.release_viewer.process_manager import (
+    ReleaseError,
+    ensure_venv,
+    ensure_worktree,
+    get_status,
+    start_process,
+    stop_process,
+    wait_until_ready,
+)
+
+i18n = I18nAuto()
+
+
+EMPTY_IFRAME = (
+    '<div style="padding:24px;color:#888;border:1px dashed #888;">'
+    "실행 중인 인스턴스가 없습니다. 태그를 선택하고 Start를 눌러주세요."
+    "</div>"
+)
+
+
+def _iframe_html(url: str) -> str:
+    if not url.startswith("http://localhost:"):
+        return (
+            '<div style="padding:16px;border:1px solid #c00;color:#c00;">'
+            f"허용되지 않은 URL입니다: {url}"
+            "</div>"
+        )
+    return (
+        f'<iframe src="{url}" width="100%" height="900" '
+        'style="border:0;"></iframe>'
+    )
+
+
+def _start_flow(label: str):
+    release = find_release(label)
+    if release is None:
+        yield "❌ 알 수 없는 태그입니다.", EMPTY_IFRAME
+        return
+    tag = release["tag"]
+    port = release["port"]
+
+    status = get_status(tag, port)
+    if status == "running":
+        yield f"✅ 이미 실행 중입니다 (포트 {port})", _iframe_html(resolve_url(release))
+        return
+
+    try:
+        yield f"⏳ worktree 준비 중… ({tag})", EMPTY_IFRAME
+        worktree = ensure_worktree(tag)
+
+        yield "🔄 의존성 설치 중… (uv sync, 최초 1회는 수 분 소요)", EMPTY_IFRAME
+        ensure_venv(worktree)
+
+        yield f"🚀 Applio 기동 중… (포트 {port})", EMPTY_IFRAME
+        start_process(release)
+
+        yield f"⌛ 기동 완료 대기 중… (최대 300초)", EMPTY_IFRAME
+        ready = wait_until_ready(port)
+        if not ready:
+            yield (
+                f"❌ 기동 대기 시간 초과 (포트 {port})",
+                EMPTY_IFRAME,
+            )
+            return
+
+        yield f"✅ 실행 중 (포트 {port})", _iframe_html(resolve_url(release))
+    except ReleaseError as exc:
+        yield f"❌ 실패: {exc}", EMPTY_IFRAME
+    except Exception as exc:  # noqa: BLE001
+        yield f"❌ 예기치 못한 에러: {exc}", EMPTY_IFRAME
+
+
+def _stop_flow(label: str):
+    release = find_release(label)
+    if release is None:
+        return "❌ 알 수 없는 태그입니다.", EMPTY_IFRAME
+    stopped = stop_process(release["tag"])
+    if stopped:
+        return f"🛑 정지됨 ({release['tag']})", EMPTY_IFRAME
+    return f"ℹ️ 실행 중인 프로세스가 없습니다 ({release['tag']})", EMPTY_IFRAME
+
+
+def release_viewer_tab():
+    choices = [r["label"] for r in RELEASES]
+    default_label = choices[0] if choices else None
+
+    gr.Markdown(
+        i18n(
+            "선택한 태그 버전의 Applio를 로컬 포트에 기동하고 아래 iframe으로 임베드합니다."
+        )
+    )
+
+    with gr.Row():
+        tag_dropdown = gr.Dropdown(
+            label=i18n("Release Tag"),
+            choices=choices,
+            value=default_label,
+            interactive=True,
+            scale=3,
+        )
+        start_btn = gr.Button(i18n("▶ Start"), variant="primary", scale=1)
+        stop_btn = gr.Button(i18n("■ Stop"), variant="stop", scale=1)
+
+    status_md = gr.Markdown(i18n("대기 중"))
+    iframe_html = gr.HTML(value=EMPTY_IFRAME)
+
+    start_btn.click(
+        fn=_start_flow,
+        inputs=tag_dropdown,
+        outputs=[status_md, iframe_html],
+    )
+    stop_btn.click(
+        fn=_stop_flow,
+        inputs=tag_dropdown,
+        outputs=[status_md, iframe_html],
+    )

--- a/tabs/release_viewer/release_viewer.py
+++ b/tabs/release_viewer/release_viewer.py
@@ -1,12 +1,20 @@
+from urllib.parse import urlparse
+
 import gradio as gr
 
 from assets.i18n.i18n import I18nAuto
-from tabs.release_viewer.config import RELEASES, find_release, resolve_url
+from tabs.release_viewer.config import (
+    ALLOWED_HOSTS,
+    RELEASES,
+    find_release,
+    resolve_url,
+)
 from tabs.release_viewer.process_manager import (
     ReleaseError,
     ensure_venv,
     ensure_worktree,
     get_status,
+    read_log_tail,
     start_process,
     stop_process,
     wait_until_ready,
@@ -23,7 +31,8 @@ EMPTY_IFRAME = (
 
 
 def _iframe_html(url: str) -> str:
-    if not url.startswith("http://localhost:"):
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or parsed.hostname not in ALLOWED_HOSTS:
         return (
             '<div style="padding:16px;border:1px solid #c00;color:#c00;">'
             f"허용되지 않은 URL입니다: {url}"
@@ -58,11 +67,12 @@ def _start_flow(label: str):
         yield f"🚀 Applio 기동 중… (포트 {port})", EMPTY_IFRAME
         start_process(release)
 
-        yield f"⌛ 기동 완료 대기 중… (최대 300초)", EMPTY_IFRAME
-        ready = wait_until_ready(port)
+        yield "⌛ 기동 완료 대기 중… (최대 300초)", EMPTY_IFRAME
+        ready, reason = wait_until_ready(tag, port)
         if not ready:
+            tail = read_log_tail(tag, lines=30)
             yield (
-                f"❌ 기동 대기 시간 초과 (포트 {port})",
+                f"❌ 기동 실패: {reason}\n\n```\n{tail}\n```",
                 EMPTY_IFRAME,
             )
             return


### PR DESCRIPTION

<img width="1550" height="1076" alt="스크린샷 2026-04-15 12-04-13" src="https://github.com/user-attachments/assets/3201fced-328a-4e51-ad47-862b5b696d51" />


  ## 요약                                                                                                                                                                                         
  - 전처리 탭 옆에 Release Viewer 탭 추가                                                                                                                                                         
  - 선택한 태그를 git worktree + uv venv로 격리 기동하고 iframe으로 임베드                                                                                                                        
  - 대상 태그 10개(3.6.2 ~ 3.2.8), 포트 7001~7010 고정                        
                                              
  ## 주요 변경                                                                                                                                                                                    
  - `tabs/release_viewer/` 신규: Dropdown + Start/Stop UI, worktree/venv/subprocess 수명주기 관리                                                                                                 
  - 태그별 `run-install.sh`를 파싱해 Python 버전과 pip 플래그 자동 추출                                                                                                                           
  - Dockerfile: git, libportaudio2, libatomic1, build-essential 추가 및 7001~7010 EXPOSE                                                                                                          
  - docker-compose: worktree 영속 볼륨, NFS 심볼릭 링크, URL 모드 env          